### PR TITLE
mklive.sh.in: Make default shell configurable

### DIFF
--- a/mklive.sh.in
+++ b/mklive.sh.in
@@ -75,6 +75,8 @@ directory if unset).
  -l <locale>        Default locale to use (en_US.UTF-8 if unset).
  -i <lz4|gzip|bzip2|xz> Compression type for the initramfs image (xz if unset).
  -s <gzip|lzo|xz>     Compression type for the squashfs image (xz if unset)
+ -S <shell>         Default shell of the root user (must be absolute path). 
+                    Set the live.shell kernel parameter to change the default shell of anon.
  -o <file>          Output file name for the ISO image (auto if unset).
  -p "pkg pkgN ..."  Install additional packages into the ISO image.
  -I <includedir>    Include directory structure under given path into rootfs
@@ -138,6 +140,11 @@ install_packages() {
     fi
     # Cleanup and remove useless stuff.
     rm -rf "$ROOTFS"/var/cache/* "$ROOTFS"/run/* "$ROOTFS"/var/run/*
+}
+
+change_shell() {
+    chroot "$ROOTFS" chsh -s "$ROOT_SHELL" root
+    [ $? -ne 0 ] && die "Failed to change the shell for root"
 }
 
 copy_include_directory() {
@@ -282,7 +289,7 @@ generate_iso_image() {
 #
 # main()
 #
-while getopts "a:b:r:c:C:T:Kk:l:i:I:s:o:p:v:h" opt; do
+while getopts "a:b:r:c:C:T:Kk:l:i:I:s:S:o:p:v:h" opt; do
     case $opt in
         a) BASE_ARCH="$OPTARG";;
         b) BASE_SYSTEM_PKG="$OPTARG";;
@@ -294,6 +301,7 @@ while getopts "a:b:r:c:C:T:Kk:l:i:I:s:o:p:v:h" opt; do
         i) INITRAMFS_COMPRESSION="$OPTARG";;
         I) INCLUDE_DIRECTORY="$OPTARG";;
         s) SQUASHFS_COMPRESSION="$OPTARG";;
+        S) ROOT_SHELL="$OPTARG";;
         o) OUTPUT_FILE="$OPTARG";;
         p) PACKAGE_LIST="$OPTARG";;
         C) BOOT_CMDLINE="$OPTARG";;
@@ -345,6 +353,7 @@ ISOLINUX_CFG="$ISOLINUX_DIR/isolinux.cfg"
 CURRENT_STEP=0
 STEP_COUNT=9
 [ -n "${INCLUDE_DIRECTORY}" ] && STEP_COUNT=$((STEP_COUNT+1))
+[ -n "$ROOT_SHELL" ] && STEP_COUNT=$((STEP_COUNT+1))
 
 : ${SYSLINUX_DATADIR:="$VOIDHOSTDIR"/usr/lib/syslinux}
 : ${GRUB_DATADIR:="$VOIDHOSTDIR"/usr/share/grub}
@@ -395,6 +404,11 @@ mkdir -p "$ROOTFS"/etc
 
 print_step "Installing void pkgs into the rootfs: ${PACKAGE_LIST} ..."
 install_packages
+
+if [ -n "$ROOT_SHELL" ]; then
+    print_step "Changing the root shell ..."
+    change_shell
+fi
 
 if [ -n "${INCLUDE_DIRECTORY}" ];then
     print_step "Copying directory structure into the rootfs: ${INCLUDE_DIRECTORY} ..."


### PR DESCRIPTION
This commit add a -S option that changes the default root shell of
the iso. It also mentions the live.shell kernel option that changes
the shell of the unprivileged user (anon).